### PR TITLE
Update BaseController example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Add this code to the top of the base controller class
 require_dependency 'dvelp_api_response/handle_request'
 serialization_scope :view_context
 
+include ActionView::Helpers::TranslationHelper
 include DvelpApiResponse::HandleRequest
 include ::VersionController
 


### PR DESCRIPTION
Why:

* Provide last working example
* New rails app doesn't include `ActionView::Helpers::TranslationHelper`
  by default but gem is using `I18n`