### PR TITLE
Added Oj gem to use as JSON serializer/deserializer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 /spec/internal/db/combustion_test.sqlite
 /spec/reports/
 /tmp/
-
+.tool-versions
+*.gem

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,6 @@
+require 'oj'
+
+Oj::Rails.set_encoder()
+Oj::Rails.set_decoder()
+Oj::Rails.optimize()
+Oj::Rails.mimic_JSON()

--- a/dvelp_api_response.gemspec
+++ b/dvelp_api_response.gemspec
@@ -32,8 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dvelp_api_auth', '0.5.0'
   spec.add_dependency 'kaminari'
   spec.add_dependency 'rails'
+  spec.add_dependency 'oj', '3.10.5'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'combustion'
   spec.add_development_dependency 'database_cleaner'

--- a/lib/dvelp_api_response/api_request_helper.rb
+++ b/lib/dvelp_api_response/api_request_helper.rb
@@ -14,7 +14,7 @@ module DvelpApiResponse
     end
 
     def parsed_response
-      @parsed_response ||= JSON.parse(response.body)
+      @parsed_response ||= parse_body(response.body)
     end
 
     def response_error(body, meta = nil)
@@ -23,8 +23,7 @@ module DvelpApiResponse
       { 'errors' => [error_message] }
     end
 
-    def api_request(method, action, params: {},
-      payload: {}, media_type: :jsonapi)
+    def api_request(method, action, params: {}, payload: {}, media_type: :jsonapi)
 
       url_params =
         if %i[update show destroy].include? action
@@ -37,7 +36,7 @@ module DvelpApiResponse
 
       process_params = { method: method, params: url_params, as: media_type }
 
-      process_params[:body] = payload.to_json if payload.present?
+      process_params[:body] = jsonify_payload(payload) if payload.present?
 
       process(
         action,
@@ -62,6 +61,14 @@ module DvelpApiResponse
 
     def fill_accept(media_type)
       request.set_header 'HTTP_ACCEPT', Mime[media_type].to_s
+    end
+
+    def jsonify_payload(hash)
+      Oj.dump(hash, mode: :rails, time_format: :ruby)
+    end
+
+    def parse_body(json)
+      Oj.load(json)
     end
   end
 end

--- a/lib/dvelp_api_response/api_request_helper.rb
+++ b/lib/dvelp_api_response/api_request_helper.rb
@@ -23,8 +23,9 @@ module DvelpApiResponse
       { 'errors' => [error_message] }
     end
 
-    def api_request(method, action, params: {}, payload: {}, media_type: :jsonapi)
-
+    def api_request(
+      method, action, params: {}, payload: {}, media_type: :jsonapi
+    )
       url_params =
         if %i[update show destroy].include? action
           { id: 1 }

--- a/lib/dvelp_api_response/handle_request.rb
+++ b/lib/dvelp_api_response/handle_request.rb
@@ -32,7 +32,7 @@ module DvelpApiResponse
       render_wrong_type_error
     rescue ActionController::ParameterMissing => e
       render_missing_parameter_error(e.param)
-    rescue JSON::ParserError => e
+    rescue Oj::ParseError, JSON::ParserError => e
       render_malformed_request_error(e)
     rescue PaymentAPIError => e
       render_payment_api_error(e)

--- a/lib/dvelp_api_response/request_validation.rb
+++ b/lib/dvelp_api_response/request_validation.rb
@@ -28,7 +28,7 @@ module DvelpApiResponse
           params
         else
           ActionController::Parameters.new(
-            JSON.parse(request.raw_post)
+            Oj.load(request.raw_post)
           )
         end
     end

--- a/lib/dvelp_api_response/version.rb
+++ b/lib/dvelp_api_response/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DvelpApiResponse
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end

--- a/spec/controllers/test_controller_spec.rb
+++ b/spec/controllers/test_controller_spec.rb
@@ -242,71 +242,24 @@ RSpec.describe TestController, type: :controller do
     end
 
     describe 'OJ (optimised json) parsing error handling' do
-      it 'renders error for missing brace' do
-        fill_auth_headers(fullpath: '/test/error_in_json_brace.jsonapi')
+      shared_examples_for 'renders error' do |url, expected_error|
+        it 'renders the corresponding error' do
+          fill_auth_headers(fullpath: "/test/#{url}.jsonapi")
 
-        api_request :get, :error_in_json_brace
+          api_request :get, url.to_sym
 
-        expect(response).to have_http_status :bad_request
+          expect(response).to have_http_status :bad_request
 
-        expect(parsed_response['errors'][0]['body'])
-          .to include('expected true () at')
+          expect(parsed_response['errors'][0]['body'])
+            .to include(expected_error)
+        end
       end
-
-      it 'renders error for badly formatted value' do
-        fill_auth_headers(fullpath: '/test/error_in_json_value.jsonapi')
-
-        api_request :get, :error_in_json_value
-
-        expect(response).to have_http_status :bad_request
-
-        expect(parsed_response['errors'][0]['body'])
-          .to include('unexpected character (this[0].a) at')
-      end
-
-      it 'renders error for badly formatted key' do
-        fill_auth_headers(fullpath: '/test/error_in_json_key.jsonapi')
-
-        api_request :get, :error_in_json_key
-
-        expect(response).to have_http_status :bad_request
-
-        expect(parsed_response['errors'][0]['body'])
-          .to include('unexpected character (this[0].is) at')
-      end
-
-      it 'renders error for missing bracket' do
-        fill_auth_headers(fullpath: '/test/error_in_json_bracket.jsonapi')
-
-        api_request :get, :error_in_json_bracket
-
-        expect(response).to have_http_status :bad_request
-
-        expect(parsed_response['errors'][0]['body'])
-          .to include('expected comma, not a hash close (this[1]) at')
-      end
-
-      it 'renders error for extra comma' do
-        fill_auth_headers(fullpath: '/test/error_in_json_comma.jsonapi')
-
-        api_request :get, :error_in_json_comma
-
-        expect(response).to have_http_status :bad_request
-
-        expect(parsed_response['errors'][0]['body'])
-          .to include('expected hash key, not an array close (this[0]) at')
-      end
-
-      it 'renders error for missing comma' do
-        fill_auth_headers(fullpath: '/test/error_in_json_comma_2.jsonapi')
-
-        api_request :get, :error_in_json_comma_2
-
-        expect(response).to have_http_status :bad_request
-
-        expect(parsed_response['errors'][0]['body'])
-          .to include('expected comma, not a string (this[0].is) at')
-      end
+      it_behaves_like 'renders error', 'error_in_json_brace', 'expected true () at'
+      it_behaves_like 'renders error', 'error_in_json_value', 'unexpected character (this[0].a) at'
+      it_behaves_like 'renders error', 'error_in_json_key', 'unexpected character (this[0].is) at'
+      it_behaves_like 'renders error', 'error_in_json_bracket', 'expected comma, not a hash close (this[1]) at'
+      it_behaves_like 'renders error', 'error_in_json_comma', 'expected hash key, not an array close (this[0]) at'
+      it_behaves_like 'renders error', 'error_in_json_comma_2', 'expected comma, not a string (this[0].is) at'
     end
 
     describe 'payment error handling' do

--- a/spec/controllers/test_controller_spec.rb
+++ b/spec/controllers/test_controller_spec.rb
@@ -254,12 +254,24 @@ RSpec.describe TestController, type: :controller do
             .to include(expected_error)
         end
       end
-      it_behaves_like 'renders error', 'error_in_json_brace', 'expected true () at'
-      it_behaves_like 'renders error', 'error_in_json_value', 'unexpected character (this[0].a) at'
-      it_behaves_like 'renders error', 'error_in_json_key', 'unexpected character (this[0].is) at'
-      it_behaves_like 'renders error', 'error_in_json_bracket', 'expected comma, not a hash close (this[1]) at'
-      it_behaves_like 'renders error', 'error_in_json_comma', 'expected hash key, not an array close (this[0]) at'
-      it_behaves_like 'renders error', 'error_in_json_comma_2', 'expected comma, not a string (this[0].is) at'
+      it_behaves_like 'renders error',
+                      'error_in_json_brace',
+                      'expected true () at'
+      it_behaves_like 'renders error',
+                      'error_in_json_value',
+                      'unexpected character (this[0].a) at'
+      it_behaves_like 'renders error',
+                      'error_in_json_key',
+                      'unexpected character (this[0].is) at'
+      it_behaves_like 'renders error',
+                      'error_in_json_bracket',
+                      'expected comma, not a hash close (this[1]) at'
+      it_behaves_like 'renders error',
+                      'error_in_json_comma',
+                      'expected hash key, not an array close (this[0]) at'
+      it_behaves_like 'renders error',
+                      'error_in_json_comma_2',
+                      'expected comma, not a string (this[0].is) at'
     end
 
     describe 'payment error handling' do

--- a/spec/factories/child_record.rb
+++ b/spec/factories/child_record.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :child_record, class: ChildRecord do
     test_record
-    name Faker::Company.name
+    name { Faker::Company.name }
   end
 end

--- a/spec/factories/test_record.rb
+++ b/spec/factories/test_record.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :test_record, class: TestRecord do
-    name Faker::Company.name
+    name { Faker::Company.name }
   end
 
   trait :with_child_records do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,9 +9,8 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'dvelp_api_response'
 
 require 'combustion'
-Combustion.initialize! :all
+Combustion.initialize! :active_record, :action_controller
 
-require 'active_model_serializers'
 require 'byebug'
 require 'database_cleaner'
 require 'dvelp_api_auth'


### PR DESCRIPTION
Features:
Improve JSON parsing in dvelp_api_response

**Change**

Change Owners: Mark Jordanovic-Lewis
Reason: Faster parsing -> Shorter response time -> More people served -> Customers happier

**Description**

Netflix fast_jsonapi touts itself as a rapid JSON loading and generating library, it is desired to approach the speeds offered by this. Reasons for minimising development lift are described in ticket. In short, the approach of dvelp_api_response is similar with less validation logic this is due to dvelp_api_response being simpler rather than less safe. Choice of JSON (de)serialiser implied a quick win in the stated desire of the ticket.

ticket: https://trello.com/c/Mfi5Doit

Validation

- specs pass and additional specs added to document changes in JSON parse error messages.
- **todo**: Local testing via postman of airline-api-manager and airline-api with dvelp_api_response.
- **todo**: Each app that leverages dvelp_api_response updated and deployed to staging and manual tested for Twilio and Twilio Flex functionality compatibility. Gemfiles pointed at github branch version of the gem.
- Observe metrics around response times, hopefully these should drop. 

**Pre-deploy Plan**
- Add dependencies in airline-api and airline-manager-api for the new gem version via github branch.
- Deploy apps to staging and see if they are stable.
- Add dependencies in all other apps which use dvelp_api_response gem and leave to see if they are stable - this will require the co-operation of devs working on related projects and what they have currently deployed.
- If all remains kosher then the Go Live Plan can be moved on to.

**Go Live Plan**
- Build and deploy dvelp_api_reponse v 0.7.2 to gemfury
- Update dependecies in all dependent apps, merge to master and deploy one by one

**Rollback plan**
- dvelp_api_responce v 0.7.1 still available on Gemfury. Rollback app Gemfiles to that and redeploy.

**Risks**
- After testing on staging to ensure response coherence and subsequent fixes there should be no issue.

**Monitoring**
_Active_
Assigned: MarkJL
- Manual observation of Sentry for an hour
- Monitor metrics around response times

_Passive_
- Watch for sentry errors in slack
- Look at metrics around response times - these _should not_ increase.

**Changes**

- Added specs to cover unfriendly error messages
- Used Oj.load and Oj.dump in place of JSON.parse and x.to_json
- Used new FactoryBot value assign syntax
- Bumped bundler version to 1.17.3
- Removed sprocket and view loading from combustion gem