### PR TITLE
Added logging for caught error

### DIFF
--- a/lib/dvelp_api_response/handle_request.rb
+++ b/lib/dvelp_api_response/handle_request.rb
@@ -50,7 +50,8 @@ module DvelpApiResponse
     def authenticate_request
       begin
         raise Unauthorized unless valid_request?
-      rescue
+      rescue => e
+        log_unknown_unauthorised_reason(e)
         raise Unauthorized
       end
       raise UnsupportedMediaType unless valid_request_media_type?
@@ -72,6 +73,12 @@ module DvelpApiResponse
           ActiveModelSerializers::Deserialization.jsonapi_parse(api_params)
         )
       end
+    end
+
+    def log_unknown_unauthorised_reason(err)
+      Rails.logger.debug "Error in validation: #{err.class}"
+      Rails.logger.debug "#{err.message}"
+      Rails.logger.debug "#{err.backtrace}"
     end
   end
 end

--- a/lib/dvelp_api_response/version.rb
+++ b/lib/dvelp_api_response/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DvelpApiResponse
-  VERSION = '0.7.2'
+  VERSION = '0.7.3'
 end


### PR DESCRIPTION
**Reason**
Internal errors in the validation call path are not debuggable.

**Description**
Added a logging method for debug output in handle_request.rb that will show the error and trace of it.